### PR TITLE
Implement custom fetch for SSE transport and add headers support in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ cp config.example.json config.json
 - **SSE-type Server**:
   - `type`: "sse" (required)
   - `url`: URL of the SSE server (required)
+  - `headers`: Object of HTTP headers to send with the SSE connection (optional)
   - `exposedTools`: Array of tools to expose (optional)
   - `hiddenTools`: Array of tools to hide (optional)
   - `envVars`: Environment variable configuration for tool arguments and responses (optional)

--- a/config.example.json
+++ b/config.example.json
@@ -21,7 +21,11 @@
     },
     "Example Server 3": {
       "type": "sse",
-      "url": "http://example.com/mcp"
+      "url": "http://example.com/sse",
+      "headers": {
+        "Authorization": "Bearer <token>",
+        "X-Custom-Header": "value"
+      }
     }
   },
   "envVars": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export type TransportConfigStdio = {
 export type TransportConfigSSE = {
   type: 'sse';
   url: string;
+  headers?: Record<string, string>;
   env?: Record<string, string>;
   exposedTools?: ExposedTool[];
   hiddenTools?: string[];


### PR DESCRIPTION
Implemented a custom fetch for SSE transport and added support for headers in the config.

## Changes
- Customized fetch initialization for SSEClientTransport to flexibly add headers
- Added headers property for SSE in config.ts

## Reason
To allow flexible addition of authentication headers and other custom headers when integrating with APIs.
