### PR TITLE
Upgrade MCP SDK to 1.28.0 with Streamable HTTP and auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,26 @@ cp config.example.json config.json
   - `exposedTools`: Array of tools to expose (optional)
   - `hiddenTools`: Array of tools to hide (optional)
   - `envVars`: Environment variable configuration for tool arguments and responses (optional)
+  - `enable`: Whether to enable the server (optional, default: true)
 
 - **SSE-type Server**:
+
   - `type`: "sse" (required)
   - `url`: URL of the SSE server (required)
   - `headers`: Object of HTTP headers to send with the SSE connection (optional)
   - `exposedTools`: Array of tools to expose (optional)
   - `hiddenTools`: Array of tools to hide (optional)
   - `envVars`: Environment variable configuration for tool arguments and responses (optional)
+  - `enable`: Whether to enable the server (optional, default: true)
+
+- **Streamable HTTP-type Server**:
+  - `type`: "streamable-http" (required)
+  - `url`: URL of the Streamable HTTP server (required)
+  - `headers`: Object of HTTP headers to send with requests (optional)
+  - `exposedTools`: Array of tools to expose (optional)
+  - `hiddenTools`: Array of tools to hide (optional)
+  - `envVars`: Environment variable configuration for tool arguments and responses (optional)
+  - `enable`: Whether to enable the server (optional, default: true)
 
 #### Tool Filtering Configuration
 
@@ -131,6 +143,33 @@ cp config.example.json config.json
     ]
     ```
 
+#### Server Transport Configuration
+
+Configure how the proxy hub itself is served via the `serverTransport` section:
+
+```json
+"serverTransport": {
+  "type": "streamable-http",
+  "port": 3006,
+  "host": "0.0.0.0",
+  "path": "/mcp",
+  "auth": {
+    "type": "bearer",
+    "token": "your-secret-token"
+  }
+}
+```
+
+- `type`: Transport type ("stdio", "sse", or "streamable-http")
+- `port`: Port number for HTTP-based transports (default: 3006)
+- `host`: Host to bind to (default: "0.0.0.0")
+- `path`: URL path for Streamable HTTP endpoint (default: "/mcp")
+- `auth`: Authentication configuration (optional)
+  - `type`: "bearer" (currently the only supported type)
+  - `token`: The bearer token required for authentication
+
+Authentication can also be configured via the `MCP_PROXY_AUTH_TOKEN` environment variable.
+
 #### Custom Tool Configuration
 
 - **tools**:
@@ -143,8 +182,11 @@ cp config.example.json config.json
 - `MCP_PROXY_CONFIG_PATH`: Path to the configuration file
 - `MCP_PROXY_LOG_DIRECTORY_PATH`: Path to the log directory
 - `MCP_PROXY_LOG_LEVEL`: Log level ("debug" or "info")
+- `MCP_PROXY_AUTH_TOKEN`: Bearer token for authenticating incoming requests to the proxy server
+- `MCP_PROXY_PATH`: URL path for Streamable HTTP endpoint (default: "/mcp")
 - `KEEP_SERVER_OPEN`: Whether to keep the server open after client disconnection in SSE mode (set to "1" to enable)
-- `PORT`: Port for the SSE server (default: 3006)
+- `PORT`: Port for the SSE/Streamable HTTP server (default: 3006)
+- `HOST`: Host to bind for the HTTP server (default: "0.0.0.0")
 
 ## Development
 
@@ -173,6 +215,8 @@ For development with continuous run:
 npm run dev
 # SSE
 npm run dev:sse
+# Streamable HTTP
+npm run dev:http
 ```
 
 ## CLI

--- a/build.ts
+++ b/build.ts
@@ -10,7 +10,7 @@ const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
 esbuild
   .build({
-    entryPoints: ['src/index.ts', 'src/sse.ts', 'src/cli.ts'],
+    entryPoints: ['src/index.ts', 'src/sse.ts', 'src/streamable-http.ts', 'src/cli.ts'],
     bundle: true,
     outdir: 'build',
     platform: 'node',

--- a/build.ts
+++ b/build.ts
@@ -3,9 +3,9 @@ import * as esbuild from 'esbuild';
 const cjsSupport = `import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 
-import url from "url";
-const __filename = url.fileURLToPath(import.meta.url);
-const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
+import __node_url__ from "url";
+const __filename = __node_url__.fileURLToPath(import.meta.url);
+const __dirname = __node_url__.fileURLToPath(new URL(".", import.meta.url));
 `;
 
 esbuild

--- a/config.example.json
+++ b/config.example.json
@@ -3,6 +3,7 @@
     "Example Server 1": {
       "command": "/path/to/server1/build/index.js",
       "exposedTools": ["tool1", { "original": "tool2", "exposed": "renamed_tool2" }],
+      "enable": true,
       "envVars": [
         { "name": "API_KEY", "value": "my-api-key", "expand": true, "unexpand": true },
         { "name": "USER_ID", "value": "user123", "expand": true, "unexpand": false },
@@ -22,10 +23,28 @@
     "Example Server 3": {
       "type": "sse",
       "url": "http://example.com/sse",
+      "enable": false,
       "headers": {
         "Authorization": "Bearer <token>",
         "X-Custom-Header": "value"
       }
+    },
+    "Example Server 4": {
+      "type": "streamable-http",
+      "url": "http://example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <token>"
+      }
+    }
+  },
+  "serverTransport": {
+    "type": "streamable-http",
+    "port": 3006,
+    "host": "0.0.0.0",
+    "path": "/mcp",
+    "auth": {
+      "type": "bearer",
+      "token": "your-secret-token"
     }
   },
   "envVars": [

--- a/docs/spec.ja.md
+++ b/docs/spec.ja.md
@@ -21,7 +21,7 @@ MCP Proxy Hub（MCPプロキシハブ）は、複数のMCP（Model Context Proto
 2. **クライアント管理** (`client.ts`)：
 
    - 設定ファイルに基づいて複数のMCPサーバーへの接続を確立・管理
-   - StdioとSSEの両方のトランスポート方式をサポート
+   - Stdio、SSE、Streamable HTTPのトランスポート方式をサポート
 
 3. **リソース/ツール/プロンプトハンドラー** (`handlers/`)：
 
@@ -43,9 +43,17 @@ MCP Proxy Hub（MCPプロキシハブ）は、複数のMCP（Model Context Proto
   - `StdioClientTransport`と`StdioServerTransport`クラスを使用
 
 - **Server-Sent Events（SSE）**：
+
   - HTTP接続を利用したサーバーとの通信に使用
   - `SSEClientTransport`と`SSEServerTransport`クラスを使用
   - 複数クライアント接続のサポート
+
+- **Streamable HTTP**：
+  - 最新のHTTPベースMCP通信方式
+  - `StreamableHTTPClientTransport`と`StreamableHTTPServerTransport`クラスを使用
+  - セッション管理（セッションID）をサポート
+  - SSEストリーミングと直接HTTPレスポンスの両方をサポート
+  - 新規導入にはSSEよりもStreamable HTTPを推奨
 
 ## Project Structure
 
@@ -191,12 +199,14 @@ MCP Proxy Hub（MCPプロキシハブ）は、複数のMCP（Model Context Proto
   - `env`: 環境変数（オプション）
   - `exposedTools`: 公開するツールの配列（オプション）
   - `hiddenTools`: 非表示にするツールの配列（オプション）
+  - `enable`: サーバーを有効にするかどうか（オプション、デフォルト: true）
 
 - **SSE型サーバー**:
   - `type`: 「sse」（必須）
   - `url`: SSEサーバーのURL（必須）
   - `exposedTools`: 公開するツールの配列（オプション）
   - `hiddenTools`: 非表示にするツールの配列（オプション）
+  - `enable`: サーバーを有効にするかどうか（オプション、デフォルト: true）
 
 #### ツールフィルタリング設定
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -21,7 +21,7 @@ MCP Proxy Hub is a proxy server that aggregates multiple MCP (Model Context Prot
 2. **Client Management** (`client.ts`):
 
    - Establishes and manages connections to multiple MCP servers based on configuration
-   - Supports both Stdio and SSE transport methods
+   - Supports Stdio, SSE, and Streamable HTTP transport methods
 
 3. **Resource/Tool/Prompt Handlers** (`handlers/`):
 
@@ -43,9 +43,17 @@ MCP Proxy Hub is a proxy server that aggregates multiple MCP (Model Context Prot
   - Uses `StdioClientTransport` and `StdioServerTransport` classes
 
 - **Server-Sent Events (SSE)**:
+
   - Used for communication with servers using HTTP connections
   - Uses `SSEClientTransport` and `SSEServerTransport` classes
   - Supports multiple client connections
+
+- **Streamable HTTP**:
+  - Modern HTTP-based transport for MCP communication
+  - Uses `StreamableHTTPClientTransport` and `StreamableHTTPServerTransport` classes
+  - Supports session management with session IDs
+  - Supports both SSE streaming and direct HTTP responses
+  - Recommended over SSE for new deployments
 
 ## Project Structure
 
@@ -191,12 +199,14 @@ MCP Proxy Hub is a proxy server that aggregates multiple MCP (Model Context Prot
   - `env`: Environment variables (optional)
   - `exposedTools`: Array of tools to expose (optional)
   - `hiddenTools`: Array of tools to hide (optional)
+  - `enable`: Whether to enable the server (optional, default: true)
 
 - **SSE-type Server**:
   - `type`: "sse" (required)
   - `url`: URL of the SSE server (required)
   - `exposedTools`: Array of tools to expose (optional)
   - `hiddenTools`: Array of tools to hide (optional)
+  - `enable`: Whether to enable the server (optional, default: true)
 
 #### Tool Filtering Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.12.3",
+        "@modelcontextprotocol/sdk": "^1.28.0",
         "@types/cors": "2.8.19",
         "commander": "14.0.0",
         "cors": "2.8.5",
@@ -22,6 +22,7 @@
       },
       "bin": {
         "mcp-proxy-hub": "build/index.js",
+        "mcp-proxy-hub-cli": "build/cli.js",
         "mcp-proxy-hub-sse": "build/sse.js"
       },
       "devDependencies": {
@@ -709,6 +710,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1216,25 +1229,59 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.3.tgz",
-      "integrity": "sha512-DyVYSOafBvk3/j1Oka4z5BWT8o4AFmoNyZY9pALOm7Lh3GZglR71Co4r4dEUoqDWdDazIZQHBe7J2Nwkg6gHgQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
+      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/eventsource": {
@@ -1247,6 +1294,74 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1899,6 +2014,7 @@
       "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.0",
         "@typescript-eslint/types": "8.34.0",
@@ -2293,6 +2409,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2314,6 +2431,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2325,6 +2443,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2430,23 +2587,27 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -2745,9 +2906,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2944,6 +3105,7 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3005,6 +3167,7 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3208,6 +3371,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3246,10 +3410,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -3257,7 +3424,7 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
     },
     "node_modules/external-editor": {
@@ -3320,6 +3487,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -3328,6 +3496,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -3694,6 +3878,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3702,29 +3896,39 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -4040,6 +4244,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4190,6 +4403,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -4221,7 +4443,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4833,6 +5062,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4879,15 +5109,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4930,17 +5161,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/readdirp": {
@@ -4953,6 +5185,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -5337,9 +5578,10 @@
       "license": "MIT"
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -5607,6 +5849,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5710,6 +5953,7 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -5769,6 +6013,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5833,6 +6078,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -5852,6 +6098,7 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5965,6 +6212,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5978,6 +6226,7 @@
       "integrity": "sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.3",
@@ -6231,6 +6480,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.28.0",
+        "@modelcontextprotocol/sdk": "1.28.0",
         "@types/cors": "2.8.19",
         "commander": "14.0.0",
         "cors": "2.8.5",
@@ -17,12 +17,13 @@
         "eventsource": "4.0.0",
         "express": "5.1.0",
         "inquirer": "12.7.0",
-        "inquirer-command-prompt": "^0.1.0",
+        "inquirer-command-prompt": "0.1.0",
         "zod-to-json-schema": "3.24.5"
       },
       "bin": {
         "mcp-proxy-hub": "build/index.js",
         "mcp-proxy-hub-cli": "build/cli.js",
+        "mcp-proxy-hub-http": "build/streamable-http.js",
         "mcp-proxy-hub-sse": "build/sse.js"
       },
       "devDependencies": {
@@ -1350,7 +1351,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2014,7 +2014,6 @@
       "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.0",
         "@typescript-eslint/types": "8.34.0",
@@ -2409,7 +2408,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3105,7 +3103,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3167,7 +3164,6 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3371,7 +3367,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3883,7 +3878,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5062,7 +5056,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5849,7 +5842,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5953,7 +5945,6 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -6013,7 +6004,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6098,7 +6088,6 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6212,7 +6201,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6226,7 +6214,6 @@
       "integrity": "sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "express",
     "stdio",
     "sse",
-    "server-sent-events"
+    "server-sent-events",
+    "streamable-http",
+    "authentication"
   ],
   "repository": {
     "type": "git",
@@ -36,6 +38,7 @@
   "bin": {
     "mcp-proxy-hub": "build/index.js",
     "mcp-proxy-hub-sse": "build/sse.js",
+    "mcp-proxy-hub-http": "build/streamable-http.js",
     "mcp-proxy-hub-cli": "build/cli.js"
   },
   "files": [
@@ -44,6 +47,7 @@
   "scripts": {
     "dev": "nodemon --watch 'src/**' --ext 'ts,json' --ignore 'src/**/*.spec.ts' --exec 'tsx src/index.ts'",
     "dev:sse": "nodemon --watch 'src/**' --ext 'ts,json' --ignore 'src/**/*.spec.ts' --exec 'tsx src/sse.ts'",
+    "dev:http": "nodemon --watch 'src/**' --ext 'ts,json' --ignore 'src/**/*.spec.ts' --exec 'tsx src/streamable-http.ts'",
     "build": "tsx build.ts",
     "prepare": "npm run build",
     "watch": "tsc --watch",
@@ -60,7 +64,7 @@
     "format:check": "prettier --check \"**/*.{ts,json,md}\""
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.12.3",
+    "@modelcontextprotocol/sdk": "^1.28.0",
     "@types/cors": "2.8.19",
     "commander": "14.0.0",
     "cors": "2.8.5",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "format:check": "prettier --check \"**/*.{ts,json,md}\""
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.28.0",
+    "@modelcontextprotocol/sdk": "1.28.0",
     "@types/cors": "2.8.19",
     "commander": "14.0.0",
     "cors": "2.8.5",
@@ -72,7 +72,7 @@
     "eventsource": "4.0.0",
     "express": "5.1.0",
     "inquirer": "12.7.0",
-    "inquirer-command-prompt": "^0.1.0",
+    "inquirer-command-prompt": "0.1.0",
     "zod-to-json-schema": "3.24.5"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,10 @@ async function handleCallCommand(
 ) {
   const args: Record<string, unknown> = {};
   for (const arg of argsStr) {
-    const [key, value] = arg.split('=');
+    const eqIndex = arg.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = arg.substring(0, eqIndex);
+    const value = arg.substring(eqIndex + 1);
     if (key && value) {
       try {
         args[key] = JSON.parse(value);
@@ -99,6 +102,84 @@ async function handleCallCommand(
   }
 }
 
+function showInteractiveModeHelp() {
+  console.log(`
+Available commands:
+  list                          List all available tools.
+  call <toolName> [args...]     Call a specific tool.
+    <toolName>                  The name of the tool to call.
+    [args...]                   Arguments for the tool in key=value format.
+                                Arrays: key=["value1","value2"]
+                                Objects: key={"a":"b"}
+    -o, --output-dir <dir>      Save output to a directory.
+  help                          Show this help message.
+  exit                          Exit the interactive mode.
+`);
+}
+
+function parseCommandLine(input: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let inQuote: string | null = null;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (inQuote) {
+      current += char;
+      if (char === inQuote && input[i - 1] !== '\\') {
+        inQuote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      inQuote = char;
+      current += char;
+      continue;
+    }
+
+    if (char === '[') {
+      bracketDepth++;
+      current += char;
+      continue;
+    }
+    if (char === ']') {
+      bracketDepth--;
+      current += char;
+      continue;
+    }
+    if (char === '{') {
+      braceDepth++;
+      current += char;
+      continue;
+    }
+    if (char === '}') {
+      braceDepth--;
+      current += char;
+      continue;
+    }
+
+    if (/\s/.test(char) && bracketDepth === 0 && braceDepth === 0) {
+      if (current) {
+        parts.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
 async function main() {
   const program = new Command();
   program.name('mcp-proxy-hub').description('A CLI for interacting with the MCP Proxy Hub');
@@ -134,6 +215,7 @@ async function main() {
     const config = await loadConfig();
     await createClients(config.mcpServers);
     await handleListCommand(config);
+    console.log('Entered interactive mode. Type "help" for available commands.');
 
     let isEnd = false;
     while (!isEnd) {
@@ -145,7 +227,7 @@ async function main() {
           message: 'mcp-proxy-hub> ',
         });
 
-        const parts = command.trim().split(/\s+/);
+        const parts = parseCommandLine(command.trim());
         const commandName = parts[0].toLowerCase();
 
         if (!commandName) {
@@ -182,10 +264,13 @@ async function main() {
             isEnd = true;
             break;
           }
+          case 'help': {
+            showInteractiveModeHelp();
+            break;
+          }
           default:
-            console.log(
-              'Unknown command. Available commands: call <toolName> [args...], list, exit'
-            );
+            console.log(`Unknown command: ${commandName}`);
+            showInteractiveModeHelp();
         }
       } catch (error) {
         logger.error('Error:', error);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { ServerConfig } from './config.js';
 import { clientMaps } from './mappers/client-maps.js';
@@ -29,7 +30,6 @@ const createClient = (
   try {
     if (config.type === 'sse') {
       const customFetch: FetchLike = (url: string | URL, init?: RequestInit) => {
-        // Custom fetch implementation to handle headers and other options
         const headers = new Headers(init?.headers);
         if (config.headers) {
           Object.entries(config.headers).forEach(([key, value]) => {
@@ -43,6 +43,23 @@ const createClient = (
       };
       transport = new SSEClientTransport(new URL(config.url), {
         eventSourceInit: { fetch: customFetch },
+      });
+    } else if (config.type === 'streamable-http') {
+      const configHeaders = config.headers;
+      const customFetch = configHeaders
+        ? (url: string | URL | Request, init?: RequestInit) => {
+            const headers = new Headers(init?.headers);
+            Object.entries(configHeaders).forEach(([key, value]) => {
+              headers.set(key, value);
+            });
+            return fetch(url, {
+              ...init,
+              headers: Object.fromEntries(headers.entries()),
+            });
+          }
+        : undefined;
+      transport = new StreamableHTTPClientTransport(new URL(config.url), {
+        fetch: customFetch,
       });
     } else {
       console.debug(`${serverName} config: ${JSON.stringify(config, null, 2)}`);
@@ -79,9 +96,8 @@ const createClient = (
     },
     {
       capabilities: {
-        prompts: {},
-        resources: { subscribe: true },
-        tools: {},
+        roots: {},
+        sampling: {},
       },
     }
   );
@@ -151,6 +167,12 @@ export const createClients = async (
     serverName: string,
     config: ServerConfig
   ): Promise<ConnectedClient | null> => {
+    // Check if server is enabled (default to true if not specified)
+    if (config.enable === false) {
+      console.log(`Server ${serverName} is disabled, skipping connection`);
+      return null;
+    }
+
     console.log(`Connecting to server: ${serverName}`);
 
     return connectWithRetry(serverName, config, async (client, transport) => {
@@ -191,6 +213,12 @@ export const restartClient = async (
   serverName: string,
   config: ServerConfig
 ): Promise<ConnectedClient | null> => {
+  // Check if server is enabled (default to true if not specified)
+  if (config.enable === false) {
+    console.log(`Server ${serverName} is disabled, skipping restart`);
+    return null;
+  }
+
   console.log(`Restarting server: ${serverName}`);
 
   // Find the client to restart

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ export type TransportConfigStdio = {
   exposedTools?: ExposedTool[];
   hiddenTools?: string[];
   envVars?: EnvVarConfig[];
+  enable?: boolean;
 };
 
 export type TransportConfigSSE = {
@@ -35,9 +36,24 @@ export type TransportConfigSSE = {
   exposedTools?: ExposedTool[];
   hiddenTools?: string[];
   envVars?: EnvVarConfig[];
+  enable?: boolean;
 };
 
-export type ServerConfig = TransportConfigSSE | TransportConfigStdio;
+export type TransportConfigStreamableHTTP = {
+  type: 'streamable-http';
+  url: string;
+  headers?: Record<string, string>;
+  env?: Record<string, string>;
+  exposedTools?: ExposedTool[];
+  hiddenTools?: string[];
+  envVars?: EnvVarConfig[];
+  enable?: boolean;
+};
+
+export type ServerConfig =
+  | TransportConfigSSE
+  | TransportConfigStdio
+  | TransportConfigStreamableHTTP;
 export type ServerName = string;
 export type ServerConfigs = Record<ServerName, ServerConfig>;
 
@@ -56,10 +72,24 @@ export type ToolConfig = {
   subtools?: Record<ServerName, SubtoolDefinition>;
 };
 
+export interface AuthConfig {
+  type: 'bearer';
+  token: string;
+}
+
+export interface ServerTransportConfig {
+  type: 'stdio' | 'sse' | 'streamable-http';
+  port?: number;
+  host?: string;
+  path?: string;
+  auth?: AuthConfig;
+}
+
 export interface Config {
   mcpServers: ServerConfigs;
   tools?: Record<string, ToolConfig>;
   envVars?: EnvVarConfig[];
+  serverTransport?: ServerTransportConfig;
 }
 
 export const loadConfig = async (): Promise<Config> => {

--- a/src/handlers/integration-tool-handlers.spec.ts
+++ b/src/handlers/integration-tool-handlers.spec.ts
@@ -131,6 +131,7 @@ describe('Integration Tests for Tool Handlers with Shared ClientMaps', () => {
     // When executeToolCall is called, return a success result
     vi.mocked(toolService.executeToolCall).mockResolvedValueOnce({
       result: 'success from client1',
+      toolResult: 'success from client1',
     });
 
     // 1. First call handleListToolsRequest to populate the clientMaps
@@ -179,7 +180,10 @@ describe('Integration Tests for Tool Handlers with Shared ClientMaps', () => {
     );
 
     // Verify tool call result
-    expect(callResult).toEqual({ result: 'success from client1' });
+    expect(callResult).toEqual({
+      result: 'success from client1',
+      toolResult: 'success from client1',
+    });
   });
 
   it('should handle tool call errors when client is not found in map', async () => {
@@ -215,7 +219,7 @@ describe('Integration Tests for Tool Handlers with Shared ClientMaps', () => {
     vi.mocked(customToolService.createCustomTools).mockReturnValueOnce([customTool]);
 
     // Mock custom tool call handling
-    const mockCustomResult = { result: 'custom-success' };
+    const mockCustomResult = { result: 'custom-success', toolResult: 'custom-success' };
     vi.mocked(customToolService.handleCustomToolCall).mockResolvedValueOnce(mockCustomResult);
 
     // Define toolsConfig with custom tool mapping
@@ -347,7 +351,10 @@ describe('Integration Tests for Tool Handlers with Shared ClientMaps', () => {
     };
 
     // Mock successful tool execution
-    vi.mocked(toolService.executeToolCall).mockResolvedValueOnce({ result: 'success' });
+    vi.mocked(toolService.executeToolCall).mockResolvedValueOnce({
+      result: 'success',
+      toolResult: 'success',
+    });
 
     // 1. First call handleListToolsRequest to register the renamed tool
     const listRequest = {

--- a/src/handlers/prompt-handlers.ts
+++ b/src/handlers/prompt-handlers.ts
@@ -3,20 +3,16 @@ import { clientMaps } from '../mappers/client-maps.js';
 import { loadConfig } from '../config.js';
 import { GetPromptResultSchema, ListPromptsResultSchema } from '@modelcontextprotocol/sdk/types.js';
 
+type PromptArgument = {
+  name: string;
+  description?: string;
+  required?: boolean;
+};
+
 type PromptType = {
   description: string;
   name: string;
-  arguments?:
-    | Zod.objectOutputType<
-        {
-          name: Zod.ZodString;
-          description: Zod.ZodOptional<Zod.ZodString>;
-          required: Zod.ZodOptional<Zod.ZodBoolean>;
-        },
-        Zod.ZodTypeAny,
-        'passthrough'
-      >[]
-    | undefined;
+  arguments?: PromptArgument[];
 };
 
 /**

--- a/src/handlers/resource-handlers.ts
+++ b/src/handlers/resource-handlers.ts
@@ -10,7 +10,7 @@ import {
 import { getConnectedClient } from '../client.js';
 import { clientMaps } from '../mappers/client-maps.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { z } from 'zod';
+import { Resource } from '@modelcontextprotocol/sdk/types.js';
 
 /**
  * Registers list resources handler on the server
@@ -18,7 +18,7 @@ import { z } from 'zod';
 export function registerListResourcesHandler(server: Server): void {
   server.setRequestHandler(ListResourcesRequestSchema, async (request) => {
     const connectedClients = getConnectedClient();
-    const allResources: z.infer<typeof ListResourcesResultSchema>['resources'] = [];
+    const allResources: Resource[] = [];
     clientMaps.clearResourceMap();
 
     for (const connectedClient of connectedClients) {

--- a/src/handlers/tool-call-handler.spec.ts
+++ b/src/handlers/tool-call-handler.spec.ts
@@ -110,7 +110,7 @@ describe('Tool Call Handler', () => {
     vi.mocked(clientMaps.getClientForTool).mockReturnValueOnce(mockCustomClient);
 
     // Mock handleCustomToolCall to return a result
-    const mockResult = { result: 'custom-success' };
+    const mockResult = { result: 'custom-success', toolResult: 'custom-success' };
     vi.mocked(customToolService.handleCustomToolCall).mockResolvedValueOnce(mockResult);
 
     const request = {
@@ -145,7 +145,7 @@ describe('Tool Call Handler', () => {
     vi.mocked(clientMaps.getClientForTool).mockReturnValueOnce(mockClient);
 
     // Mock executeToolCall to return a result
-    const mockResult = { result: 'success' };
+    const mockResult = { result: 'success', toolResult: 'success' };
     vi.mocked(toolService.executeToolCall).mockResolvedValueOnce(mockResult);
 
     const request = {
@@ -182,7 +182,7 @@ describe('Tool Call Handler', () => {
     vi.mocked(clientMaps.getClientForTool).mockReturnValueOnce(mockClient);
 
     // Mock executeToolCall to return a result
-    const mockResult = { result: 'success' };
+    const mockResult = { result: 'success', toolResult: 'success' };
     vi.mocked(toolService.executeToolCall).mockResolvedValueOnce(mockResult);
 
     const request = {
@@ -216,7 +216,7 @@ describe('Tool Call Handler', () => {
     vi.mocked(clientMaps.getClientForTool).mockReturnValueOnce(mockClient);
 
     // Mock executeToolCall to return a result
-    const mockResult = { result: 'success' };
+    const mockResult = { result: 'success', toolResult: 'success' };
     vi.mocked(toolService.executeToolCall).mockResolvedValueOnce(mockResult);
 
     const request = {
@@ -250,6 +250,7 @@ describe('Tool Call Handler', () => {
     const mockResult = {
       success: true,
       data: 'Response contains test-value token',
+      toolResult: 'Response contains test-value token' as unknown,
     };
     vi.mocked(toolService.executeToolCall).mockResolvedValueOnce(mockResult);
 
@@ -276,6 +277,7 @@ describe('Tool Call Handler', () => {
     expect(result).toEqual({
       success: true,
       data: 'Response contains ${TEST_VAR} token',
+      toolResult: 'Response contains ${TEST_VAR} token',
     });
   });
 
@@ -284,7 +286,10 @@ describe('Tool Call Handler', () => {
     vi.mocked(clientMaps.getClientForTool).mockReturnValueOnce(mockClient);
 
     // Mock executeToolCall to return a result
-    vi.mocked(toolService.executeToolCall).mockResolvedValueOnce({ result: 'success' });
+    vi.mocked(toolService.executeToolCall).mockResolvedValueOnce({
+      result: 'success',
+      toolResult: 'success',
+    });
 
     const request = {
       method: 'tools/call' as const,

--- a/src/handlers/tool-handlers.spec.ts
+++ b/src/handlers/tool-handlers.spec.ts
@@ -262,7 +262,7 @@ describe('Tool Handlers', () => {
       vi.mocked(clientMaps.getClientForTool).mockReturnValueOnce(mockCustomClient);
 
       // Mock customToolService.handleCustomToolCall
-      const mockResult = { result: 'custom tool result' };
+      const mockResult = { result: 'custom tool result', toolResult: 'custom tool result' };
       vi.mocked(customToolService.handleCustomToolCall).mockResolvedValueOnce(mockResult);
 
       const request = {
@@ -300,7 +300,7 @@ describe('Tool Handlers', () => {
       };
 
       // Mock executeToolCall to return a result
-      const mockResult = { result: 'success' };
+      const mockResult = { result: 'success', toolResult: 'success' };
       vi.mocked(toolService.executeToolCall).mockResolvedValueOnce(mockResult);
 
       const request = {

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -2,15 +2,34 @@
 
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import express from 'express';
+import cors from 'cors';
 import { createServer } from './mcp-proxy.js';
+import { loadConfig } from './config.js';
 import 'dotenv/config';
 
 const app = express();
 
+app.use(cors());
+
 async function main() {
+  const config = await loadConfig();
   const { server, cleanup } = await createServer();
 
   let transport: SSEServerTransport;
+
+  // Bearer token auth middleware
+  const authToken = config.serverTransport?.auth?.token || process.env.MCP_PROXY_AUTH_TOKEN;
+  if (authToken) {
+    app.use((req, res, next) => {
+      const authorization = req.headers.authorization;
+      if (!authorization || authorization !== `Bearer ${authToken}`) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      next();
+    });
+    console.log('Bearer token authentication enabled');
+  }
 
   app.get('/sse', async (req, res) => {
     console.log('Received connection');
@@ -36,10 +55,15 @@ async function main() {
     await transport.handlePostMessage(req, res);
   });
 
-  const PORT = process.env.PORT || 3006;
-  app.listen(PORT, () => {
-    console.log(`Server is running on port ${PORT}`);
+  const PORT = config.serverTransport?.port || Number(process.env.PORT) || 3006;
+  const HOST = config.serverTransport?.host || process.env.HOST || '0.0.0.0';
+
+  app.listen(PORT, HOST, () => {
+    console.log(`SSE server running at http://${HOST}:${PORT}/sse`);
   });
 }
 
-main();
+main().catch((error) => {
+  console.error('Error during server startup:', error);
+  process.exit(1);
+});

--- a/src/streamable-http.ts
+++ b/src/streamable-http.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import { randomUUID } from 'crypto';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+import cors from 'cors';
+import { createServer } from './mcp-proxy.js';
+import { loadConfig } from './config.js';
+import 'dotenv/config';
+
+const app = express();
+
+app.use(cors());
+
+async function main() {
+  const config = await loadConfig();
+  const { server, cleanup } = await createServer();
+
+  // Map to store transports by session ID for stateful mode
+  const transports = new Map<string, StreamableHTTPServerTransport>();
+
+  // Bearer token auth middleware
+  const authToken = config.serverTransport?.auth?.token || process.env.MCP_PROXY_AUTH_TOKEN;
+  if (authToken) {
+    app.use((req, res, next) => {
+      const authorization = req.headers.authorization;
+      if (!authorization || authorization !== `Bearer ${authToken}`) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      next();
+    });
+    console.log('Bearer token authentication enabled');
+  }
+
+  const mcpPath = config.serverTransport?.path || process.env.MCP_PROXY_PATH || '/mcp';
+
+  function getSessionId(req: express.Request): string | undefined {
+    const value = req.headers['mcp-session-id'];
+    return typeof value === 'string' ? value : undefined;
+  }
+
+  // Handle POST requests for client-to-server communication
+  app.post(mcpPath, async (req, res) => {
+    const sessionId = getSessionId(req);
+
+    // Check for existing session
+    if (sessionId && transports.has(sessionId)) {
+      const transport = transports.get(sessionId)!;
+      await transport.handleRequest(req, res);
+      return;
+    }
+
+    // New session - create transport and connect
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+    });
+
+    transport.onclose = () => {
+      if (transport.sessionId) {
+        transports.delete(transport.sessionId);
+      }
+    };
+
+    await server.connect(transport);
+
+    if (transport.sessionId) {
+      transports.set(transport.sessionId, transport);
+    }
+
+    await transport.handleRequest(req, res);
+  });
+
+  // Handle GET requests for server-to-client notifications via SSE
+  app.get(mcpPath, async (req, res) => {
+    const sessionId = getSessionId(req);
+    if (!sessionId || !transports.has(sessionId)) {
+      res.status(400).json({ error: 'Invalid or missing session ID' });
+      return;
+    }
+
+    const transport = transports.get(sessionId)!;
+    await transport.handleRequest(req, res);
+  });
+
+  // Handle DELETE requests for session termination
+  app.delete(mcpPath, async (req, res) => {
+    const sessionId = getSessionId(req);
+    if (!sessionId || !transports.has(sessionId)) {
+      res.status(400).json({ error: 'Invalid or missing session ID' });
+      return;
+    }
+
+    const transport = transports.get(sessionId)!;
+    await transport.close();
+    transports.delete(sessionId);
+    res.status(200).json({ message: 'Session terminated' });
+  });
+
+  const PORT = config.serverTransport?.port || Number(process.env.PORT) || 3006;
+  const HOST = config.serverTransport?.host || process.env.HOST || '0.0.0.0';
+
+  const httpServer = app.listen(PORT, HOST, () => {
+    console.log(`Streamable HTTP server running at http://${HOST}:${PORT}${mcpPath}`);
+  });
+
+  async function exit() {
+    console.log('Shutting down...');
+    // Close all active transports
+    for (const [, transport] of transports) {
+      await transport.close();
+    }
+    transports.clear();
+    await cleanup();
+    await server.close();
+    httpServer.close();
+    process.exit(0);
+  }
+
+  process.on('SIGINT', exit);
+  process.on('SIGTERM', exit);
+}
+
+main().catch((error) => {
+  console.error('Error during server startup:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Upgrade `@modelcontextprotocol/sdk` from 1.12.3 to 1.28.0
- Add Streamable HTTP server transport (`src/streamable-http.ts`) for serving the proxy hub
- Add Streamable HTTP client transport for connecting to upstream servers
- Add bearer token authentication support for SSE and Streamable HTTP server transports
- Add `serverTransport` config section for port, host, path, and auth settings
- Fix array and object argument type handling in CLI interactive mode
- Fix Zod v3/v4 compatibility issues in handlers and test files
- Update `config.example.json`, README, and spec docs

## Changes

### Streamable HTTP Support
- New `streamable-http` transport type for both server and client connections
- Configurable via `serverTransport` section in config with port, host, path options

### Authentication
- Bearer token authentication for HTTP-based server transports
- Configured via `serverTransport.auth` section

### CLI Fix
- Split `key=value` on first `=` only so JSON values like `[\"a\",\"b\"]` are preserved
- Bracket/brace-aware command line parser for interactive mode so spaces inside `[]` and `{}` don't break argument boundaries

## Test plan
- [ ] Verify Streamable HTTP server transport starts and accepts connections
- [ ] Verify bearer token auth rejects unauthorized requests
- [ ] Verify CLI correctly parses array/object arguments
- [ ] Run existing test suite to confirm no regressions