### PR TITLE
Switch npm publish workflow to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,6 +58,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to NPM
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance


### PR DESCRIPTION
Migrate the npm publish workflow from a long-lived `NPM_TOKEN` to npm Trusted Publishing via GitHub Actions OIDC.

## Why

The previous `NPM_TOKEN`-based publishing has two recurring pain points:

- Token expiration causes release-time failures. The `0.1.8` release failed with a `404 Not Found` from the registry, which was actually an expired-token symptom (npm returns 404 instead of 403 for unauthorized writes).
- 2FA-required accounts/packages cannot publish through standard tokens without using the legacy "Automation" token type.

Trusted Publishing eliminates both — no token to rotate, no 2FA conflict, and the published tarball gets a Sigstore provenance attestation visible on npmjs.com.

## Changes

- Add `id-token: write` permission so the runner can mint an OIDC token.
- Drop `NODE_AUTH_TOKEN` from the publish step.
- Add `--provenance` to `npm publish` to attach a provenance statement.